### PR TITLE
Tourtel (x2)

### DIFF
--- a/20c/20c-tourtel-biography/README.md
+++ b/20c/20c-tourtel-biography/README.md
@@ -1,17 +1,20 @@
 <a href="https://www.kent-maps.online"><img src="https://kent-map.github.io/mdpress/juncture/ve-button.png"></a>
-<param ve-config title="Mary Tourtel (1874-1948)" author="Grace Conium" layout="vtl" banner="https://raw.githubusercontent.com/kent-map/images/main/banners/19c.jpg">
+<param ve-config title="Mary Tourtel (1874-1948)" author="Grace Conium" layout="vtl" banner="https://raw.githubusercontent.com/kent-map/images/main/banners/19c.jpg" Description="Grace Conium introduces Kent illustrator and author Mary Tourtel (nee Caldwell) creator of Rupert Bear.">
 
-<param ve-entity eid="Q29303" aliases="Canterbury">
-<param ve-entity eid="Q7148079" aliases="Patrixbourne">
+<!-- Historical map layers -->
+<param ve-map-layer active allmaps allmaps-id="121dee41dae035be" title="Bartholomew Kent 1919">
 
 #
 
 Mary Tourtel (nee Caldwell) was the last child of Sarah and Samuel Caldwell. She was born in 1874 in 52 Palace Street in [Canterbury](/19c/19c-canterbury), where she grew up. Her father and one brother were stonemasons and stained-glass designers at Canterbury Cathedral. Her eldest brother, Edmund, was also an artist with an interest in painting animals.
-<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus.jpg" label="Mary Tourtel at her home in Palace Street, Canterbury. Circa 1895." attribution="©Canterbury Museums and Galleries"> 
-<param ve-map center="Q29303" zoom="8">
+<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus.jpg" label="Mary Tourtel at her home in Palace Street, Canterbury. Circa 1895." attribution="©Canterbury Museums and Galleries">
+<param ve-entity eid="Q29303" aliases="Canterbury">
+<param ve-map center="Q29303" zoom="12">
 
 Mary went to school in [Canterbury](/19c/19c-canterbury). Like her father and brothers, she had an interest in art and attended the Sidney Cooper School of Art under Thomas Sidney Cooper. She had a particular fondness and ability for capturing the likenesses of animals. Before becoming the writer and illustrator of [Rupert Bear](/20c/20c-rupert-bear) for the _Daily Express_ in 1920, she created characters and scenes more akin to the [Kentish landscape](/landscape/kentish-landscapes). 
-<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Sidney_Cooper.jpg" label="The Sidney Cooper Gallery" attribution="© Martin Crowther"> 
+<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Sidney_Cooper.jpg" label="The Sidney Cooper Gallery" attribution="© Martin Crowther">
+<param ve-entity eid="Q29303" aliases="Canterbury">
+<param ve-map center="Q29303" zoom="12">
 
 Animal books for children featured greatly in Mary’s career as an illustrator. Her first publications _A Horse Book_ and _Three Little Foxes_ appeared in 1897 when she was only 23. _The Rabbit Book_ are other examples of her early work. A handkerchief book, _When Animals Work_, was published in 1919 by Sefton. 
 <param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus__4.jpg" label="©Canterbury Museums and Galleries. Three Little Foxes."> 
@@ -20,10 +23,14 @@ The scenery drawn by Mary is idealist, often featuring vast green spaces, countr
 <param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus__3.jpg" label="Gentleness from ‘Horses at Work’" attribution="©Canterbury Museums and Galleries"> 
 
 This clear influence is highlighted in the diary of Herbert Tourtel, Mary’s husband. On 21st August 1899, he wrote of an outing with Portia (his nickname for Mary): “We came on to the Patrixbourne farm in the hope of sketching some carthorses, but just arrived as they were going into the stables for their dinner. We came on to my rooms, had lunch, then returned and Portia sketched the horses. One man was very fond of his horses & quite in rapture with a sketch of his head which Pet made.”
-<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus__2.jpg" label="Kicking from ‘Horses at Work’" attribution="©Canterbury Museums and Galleries"> 
+<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus__2.jpg" label="Kicking from ‘Horses at Work’" attribution="©Canterbury Museums and Galleries">
+<param ve-entity eid="Q7148079" aliases="Patrixbourne">
+<param ve-map center="Q7148079" zoom="13">
 
 It was not only the natural landscapes that inspired Tourtel’s work. She also created artworks inspired by the architecture, including the Cathedral at [Canterbury](/19c/19c-canterbury), where her father worked as a stonemason and stained-glass designer. This watercolour is entitled ‘Canterbury Cloisters,’ and was painted by Mary in 1894 when she was 20 years old. 
-<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus__5.jpg" label="Canterbury Cloisters" attribution="©Canterbury Museums and Galleries"> 
+<param ve-image url="https://raw.githubusercontent.com/kent-map/images/main/20c/Tourtel_cantmus__5.jpg" label="Canterbury Cloisters" attribution="©Canterbury Museums and Galleries">
+<param ve-entity eid="Q29303" aliases="Canterbury">
+<param ve-map center="Q29303" zoom="12">
  
 ### References
 

--- a/children/README.md
+++ b/children/README.md
@@ -47,7 +47,7 @@ E.Nesbit spent her formative years in Halstead, near Sevenoaks. A keen oarswoman
 
 ## Rupert Bear
 
-[Rupert Bear](/20c/20c-rupert-bear)
+[Rupert Bear](/20c/20c-rupert-bear-biography)
 
 ![](https://raw.githubusercontent.com/kent-map/images/main/thumbnails/children_Rupert_Bear.jpg)
 
@@ -55,7 +55,7 @@ Rupert Bear is a children’s comic strip character first published on the 8th N
 
 ## Mary Tourtel
 
-[Mary Tourtel](/19c/19c-tourtel-biography)
+[Mary Tourtel](/20c/20c-tourtel-biography)
 
 ![](https://raw.githubusercontent.com/kent-map/images/main/thumbnails/children_Mary_Tourtel.jpg)
 


### PR DESCRIPTION
Fix for open Issue #1052:

https://www.kent-maps.online/children/
Replaced '/19c/19c-tourtel-biography' with '/20c/20c-tourtel-biography/' in Mary Tourtel item - essay link.

https://www.kent-maps.online/20c/20c-tourtel-biography/
Added 'Description' and historical map overlay: 'Bartholomew Kent 1919'